### PR TITLE
Fix doSaveExamResultsRequestArrayParamsHaveCorrectElements

### DIFF
--- a/routes/exams/middleware/studentsValidation.js
+++ b/routes/exams/middleware/studentsValidation.js
@@ -190,7 +190,7 @@ async function doSaveExamResultsRequestArrayParamsHaveCorrectElements(
     next();
   } else {
     res.status(400);
-    res.json({ error: errorMessages });
+    res.json({ error: createList(errorMessages) });
   }
 }
 


### PR DESCRIPTION
`doSaveExamResultsRequestArrayParamsHaveCorrectElements` sent a array instead of a string for a error message