### PR TITLE
Fix Mistakes In Students Routes Tests

### DIFF
--- a/test/exam-students-routes.js
+++ b/test/exam-students-routes.js
@@ -138,6 +138,7 @@ describe('/api/v1/exams/students/:examId', () => {
         });
     });
   });
+
   describe('DELETE', () => {
     it('should delete student successfully', (done) => {
       const requestObject = { studentId };
@@ -187,7 +188,7 @@ describe('/api/v1/exams/students/:examId', () => {
   });
 });
 
-describe.only('api/v1/exams/students/save-exam-results/:examId', () => {
+describe('api/v1/exams/students/save-exam-results/:examId', () => {
   before((done) => {
     chai
       .request(app)


### PR DESCRIPTION
I added a missing space and removed a `only` from `describe` block.
